### PR TITLE
add colon & space to gov comm chair list

### DIFF
--- a/themes/carpentries/layouts/shortcodes/committees.html
+++ b/themes/carpentries/layouts/shortcodes/committees.html
@@ -21,7 +21,7 @@
     <strong>{{ .committee_name }}</strong>
     <ul>
       {{ with .chair }}
-      <li><strong>Chair</strong>{{ . }}</li>
+      <li><strong>Chair: </strong>{{ . }}</li>
       {{ end }}
       {{ with .members }}
         {{ range . }}


### PR DESCRIPTION
The shortcode for the governance committee page was missing a colon & space.