### PR TITLE
allow links in logo grid

### DIFF
--- a/themes/carpentries/layouts/partials/blocks/templates/logo-grid.html
+++ b/themes/carpentries/layouts/partials/blocks/templates/logo-grid.html
@@ -6,15 +6,19 @@
         <p class="text-lg text-gray-mid">We are supported by our member organisations, those who sponsor workshops, as well as grants and donations from various sources.</p>
       </div>
 
-      {{ with .logos }}
       <div class="grid max-w-6xl grid-cols-2 gap-10 mx-auto md:grid-cols-4">
-        {{ range . }}
+        {{ range .logos }}
         <div class="flex items-center mx-auto">
-          <img src="{{ . }}">
+          {{ with .url }}
+          <a href="{{ . }}">
+          {{ end }}
+            <img src="{{ .logo }}">
+          {{ with .url }}
+          </a>
+          {{ end }}
         </div>
         {{ end }}
       </div>
-      {{ end }}
 
       {{ with $cta := .cta }}
       {{ with .url }}


### PR DESCRIPTION
Allow links in the logo grid. fixes #84 

```
  logos:
  - logo: moore-logo.svg
    url: https://www.apple.com
  - logo: alfred-sloan-logo.svg
  - logo: chan-zuck-logo.svg
  - logo: r-studio-logo.svg
```