### PR TITLE
fix typo closing quote

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -32,7 +32,7 @@ blocks:
   title: Our volunteer-led workshops are small, hands on, and interactive.
   cta:
     copy: Find a workshop
-    url: '/workshops/upcoming-workshops/"
+    url: '/workshops/upcoming-workshops/'
 - layout: quote-slider
   slides:
     - quote: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.


### PR DESCRIPTION
Fixed typo on closing quote for link on index page that was causing the link to break and the next section to not build correctly.  