### PR TITLE
cta dropdown arrow only

### DIFF
--- a/themes/carpentries/assets/css/config/_colors.js
+++ b/themes/carpentries/assets/css/config/_colors.js
@@ -19,7 +19,8 @@ module.exports = (theme) => ({
     'light': '#E6F1FF',
     'bright': '#0044D7',
     'mid': '#002B66',
-    'hover': '#0a58ca'
+    'hover': '#0a58ca',
+    'dark':'#081457'
   },
   offwhite: '#FFF7F1',
   gray: {

--- a/themes/carpentries/layouts/partials/blocks/templates/select-cta.html
+++ b/themes/carpentries/layouts/partials/blocks/templates/select-cta.html
@@ -1,7 +1,7 @@
 {{ with .block }}
   <div class="py-10 bg-blue-light">
     <div class="container flex items-center justify-center mx-auto space-x-2 text-lg">
-      <div>I want to</div>
+      <div class="text-blue-dark font-bold">I want to</div>
       <div class="inline-flex justify-center">
         <div
             x-data="{

--- a/themes/carpentries/layouts/partials/blocks/templates/select-cta.html
+++ b/themes/carpentries/layouts/partials/blocks/templates/select-cta.html
@@ -37,7 +37,7 @@
                 type="button"
                 class="flex items-center gap-2 font-bold underline"
             >
-                Become a volunteer
+              
 
                 <!-- Heroicon: chevron-down -->
                 <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 text-gray-400" viewBox="0 0 20 20" fill="currentColor">

--- a/themes/carpentries/layouts/partials/blocks/templates/select-cta.html
+++ b/themes/carpentries/layouts/partials/blocks/templates/select-cta.html
@@ -1,9 +1,9 @@
 {{ with .block }}
   <div class="py-10 bg-blue-light">
     <div class="container flex items-center justify-center mx-auto space-x-2 text-lg">
-      <div class="text-blue-dark font-bold">I want to</div>
+      <div class="font-bold">I want to</div>
       <div class="inline-flex justify-center">
-        <div
+        <div   
             x-data="{
                 open: false,
                 toggle() {


### PR DESCRIPTION
Per suggestion from @OscarSiba, make the call to action dropdown on the front page just show a dropdown arrow, and not show any menu items until it is clicked.