### PR TITLE
add lesson program filter to workshop filter

### DIFF
--- a/themes/carpentries/layouts/_default/workshops.html
+++ b/themes/carpentries/layouts/_default/workshops.html
@@ -27,6 +27,10 @@
           "key" "curriculum"
           "label" "Curriculum"
         )
+        (dict
+          "key" "type"
+          "label" "Lesson Program"
+        )
       )
     }}
     {{ $filters = partialCached "func/GetFiltersFromEntries" $filtersArgs "WorkshopFilters" }}

--- a/themes/carpentries/layouts/partials/func/ParseWorkshop.html
+++ b/themes/carpentries/layouts/partials/func/ParseWorkshop.html
@@ -38,6 +38,7 @@
       String (.country)
       String (.meeting)
       String (.curriculum)
+      String (.type)
     Map (.type)
       String (.key)
       String (.name)
@@ -188,6 +189,10 @@
   {{ with .curriculum }}
     {{ $s.SetInMap "filters" "curriculum" .name }}
   {{ end }}
+  {{ with .type }}
+    {{ $s.SetInMap "filters" "type" .name }}
+  {{ end }}
+
 {{ end }}
 {{ with $s.Get "filters" }}
   {{ $s.SetInMap "data" "filters" . }}


### PR DESCRIPTION
This PR begins to address what I am asking about in #110. 
Since the idea was to have the option to generate pages that would allow the user to filter on any properly formatted data set, I wanted to explore how this works myself.  This PR adds in a new filter option of workshop Lesson Program (type), but I can't figure out why [the script](https://github.com/carpentries/tnd-carpentries-working/blob/main/themes/carpentries/layouts/partials/func/ParseWorkshop.html#L92) is only recognizing "Circuits" workshops.  